### PR TITLE
Fix parse and parse_title conflict

### DIFF
--- a/PTT/__init__.py
+++ b/PTT/__init__.py
@@ -5,7 +5,7 @@ _parser = Parser()
 add_defaults(_parser)
 
 
-def parse(raw_title: str) -> dict:
+def parse_title(raw_title: str) -> dict:
     """
     Parse the given input string using the initialized parser instance.
     :param raw_title: The input raw torrent title to parse.

--- a/tests/test_site.py
+++ b/tests/test_site.py
@@ -1,20 +1,23 @@
 import pytest
 
-from PTT import parse
+import PTT
 
 
-@pytest.mark.parametrize("release_name, expected_site", [
-    ("The.Expanse.S05E02.1080p.AMZN.WEB.DDP5.1.x264-NTb[eztv.re].mp4", "eztv.re"),
-    ("www.1TamilBlasters.lat - Thuritham (2023) [Tamil - 2K QHD AVC UNTOUCHED - x264 - AAC - 3.4GB - ESub].mkv", "www.1TamilBlasters.lat"),
-    ("www.1TamilMV.world - Raja Vikramarka (2024) Tamil HQ HDRip - 400MB - x264 - AAC - ESub.mkv", "www.1TamilMV.world"),
-    ("Anatomia De Grey - Temporada 19 [HDTV][Cap.1905][Castellano][www.AtomoHD.nu].avi", "www.AtomoHD.nu"),
-    ("[HD-ELITE.NET] -  The.Art.Of.The.Steal.2014.DVDRip.XviD.Dual.Aud", "HD-ELITE.NET"),
-    ("[ Torrent9.cz ] The.InBetween.S01E10.FiNAL.HDTV.XviD-EXTREME.avi", "Torrent9.cz"),
-    ("Jurassic.World.Dominion.CUSTOM.EXTENDED.2022.2160p.MULTi.VF2.UHD.Blu-ray.REMUX.HDR.DoVi.HEVC.DTS-X.DTS-HDHRA.7.1-MOONLY.mkv", None),
-    ("Last.Call.for.Istanbul.2023.1080p.NF.WEB-DL.DDP5.1.H.264.MKV.torrent", None),
-])
+@pytest.mark.parametrize(
+    "release_name, expected_site",
+    [
+        ("The.Expanse.S05E02.1080p.AMZN.WEB.DDP5.1.x264-NTb[eztv.re].mp4", "eztv.re"),
+        ("www.1TamilBlasters.lat - Thuritham (2023) [Tamil - 2K QHD AVC UNTOUCHED - x264 - AAC - 3.4GB - ESub].mkv", "www.1TamilBlasters.lat"),
+        ("www.1TamilMV.world - Raja Vikramarka (2024) Tamil HQ HDRip - 400MB - x264 - AAC - ESub.mkv", "www.1TamilMV.world"),
+        ("Anatomia De Grey - Temporada 19 [HDTV][Cap.1905][Castellano][www.AtomoHD.nu].avi", "www.AtomoHD.nu"),
+        ("[HD-ELITE.NET] -  The.Art.Of.The.Steal.2014.DVDRip.XviD.Dual.Aud", "HD-ELITE.NET"),
+        ("[ Torrent9.cz ] The.InBetween.S01E10.FiNAL.HDTV.XviD-EXTREME.avi", "Torrent9.cz"),
+        ("Jurassic.World.Dominion.CUSTOM.EXTENDED.2022.2160p.MULTi.VF2.UHD.Blu-ray.REMUX.HDR.DoVi.HEVC.DTS-X.DTS-HDHRA.7.1-MOONLY.mkv", None),
+        ("Last.Call.for.Istanbul.2023.1080p.NF.WEB-DL.DDP5.1.H.264.MKV.torrent", None),
+    ],
+)
 def test_group_detection(release_name, expected_site):
-    result = parse(release_name)
+    result = PTT.parse_title(release_name)
     if expected_site:
         assert result.get("site") == expected_site, f"Incorrect site detected for {release_name}"
     else:

--- a/tests/test_size.py
+++ b/tests/test_size.py
@@ -13,7 +13,7 @@ import PTT
     ],
 )
 def test_group_detection(release_name, expected_size):
-    result = PTT.parse(release_name)
+    result = PTT.parse_title(release_name)
     if expected_size:
         assert result.get("size") == expected_size, f"Incorrect site detected for {release_name}"
     else:


### PR DESCRIPTION
`parse` is file as well as the function, this is a bit of confusing. As I created the docs, and `__all__` still pointing out to the older code. So created this pr for that. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Improved clarity in function naming by renaming `parse` to `parse_title`, making it clear that the function parses titles.
  
- **Bug Fixes**
	- Updated test cases to reflect the new function name, ensuring all tests accurately relate to current functionality. 

- **Documentation**
	- Enhanced readability and organization in the test case parameterization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->