### PR TITLE
fix: allow hyphen, dot or space when parsing for HDR10plus

### DIFF
--- a/PTT/handlers.py
+++ b/PTT/handlers.py
@@ -219,7 +219,7 @@ def add_defaults(parser: Parser):
 
     # HDR
     parser.add_handler("hdr", regex.compile(r"\bDV\b|dolby.?vision|\bDoVi\b", regex.IGNORECASE), uniq_concat(value("DV")), {"remove": True, "skipIfAlreadyFound": False})
-    parser.add_handler("hdr", regex.compile(r"HDR10(?:\+|plus)", regex.IGNORECASE), uniq_concat(value("HDR10+")), {"remove": True, "skipIfAlreadyFound": False})
+    parser.add_handler("hdr", regex.compile(r"HDR10(?:\+|[-\.\s]?plus)", regex.IGNORECASE), uniq_concat(value("HDR10+")), {"remove": True, "skipIfAlreadyFound": False})
     parser.add_handler("hdr", regex.compile(r"\bHDR(?:10)?\b", regex.IGNORECASE), uniq_concat(value("HDR")), {"remove": True, "skipIfAlreadyFound": False})
     parser.add_handler("hdr", regex.compile(r"\bSDR\b", regex.IGNORECASE), uniq_concat(value("SDR")), {"remove": True, "skipIfAlreadyFound": False})
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced HDR10 pattern matching to accommodate additional formatting variations.
	- Introduced a new handler for detecting and removing file sizes in MB, GB, or TB formats.

- **Bug Fixes**
	- Improved regex accuracy for HDR10+ string recognition.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->